### PR TITLE
Add Dockerfile and compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use official Python 3.11 image
+FROM python:3.11-slim
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        libpq-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+RUN pip install --no-cache-dir redis psycopg2-binary
+
+# Set work directory
+WORKDIR /app
+
+# Copy source
+COPY . /app
+
+# Default command
+CMD ["python", "cli/__init__.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: writer
+      POSTGRES_PASSWORD: writerpass
+      POSTGRES_DB: writerdb
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
+  app:
+    build: .
+    command: ["python", "cli/__init__.py"]
+    volumes:
+      - .:/app
+    environment:
+      DATABASE_URL: postgresql://writer:writerpass@postgres:5432/writerdb
+      REDIS_HOST: redis
+    depends_on:
+      - postgres
+      - redis
+    ports:
+      - "8000:8000"
+
+volumes:
+  pgdata:

--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -1,17 +1,29 @@
 # Docker Setup
 
-The project is containerized for easy deployment and reproducibility. A `Dockerfile` will build an environment with Python, Redis (for short-term memory), and database drivers.
+The repository includes a `Dockerfile` and `docker-compose.yml` for building and running WriterAgents with its service dependencies.
 
-## Basic Usage
+## Build the Image
 
-1. Build the image:
-   ```bash
-   docker build -t writeragents .
-   ```
-2. Run the container:
-   ```bash
-   docker run -it writeragents
-   ```
+From the repository root run:
 
-For persistent storage, mount a volume for the database location and configure Redis as needed.
+```bash
+docker build -t writeragents .
+```
 
+This creates an image with Python 3.11, Redis and PostgreSQL client libraries pre-installed.
+
+## Run with Docker Compose
+
+Use `docker-compose` to start PostgreSQL, Redis and the application container:
+
+```bash
+docker-compose up
+```
+
+The application mounts the project directory for live editing. PostgreSQL data is persisted in the `pgdata` volume.
+
+Stop the services with `Ctrl+C` and remove containers using:
+
+```bash
+docker-compose down
+```


### PR DESCRIPTION
## Summary
- add Dockerfile with Python 3.11 and DB drivers
- define `docker-compose.yml` for PostgreSQL, Redis and app services
- document build and run steps in `docs/docker_setup.md`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- ❌ `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef151627483219b8103761ef39ea2