### PR TITLE
Add Makefile for docker commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+# Simple Makefile for container management
+
+APP_TAG ?= writeragents
+
+.PHONY: build up test down
+
+build:
+	docker build -t $(APP_TAG) .
+
+up:
+	docker compose up -d
+
+test:
+	docker compose run --rm app pytest
+
+down:
+	docker compose down

--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ Agents communicate through short-term and long-term storage mechanisms. The CLI 
 3. Iterate on agent interactions and expand storage options.
 
 Additional documentation is available in the [docs/](docs/) directory.
+
+## Makefile Commands
+
+Common development tasks can be run via the provided `Makefile`:
+
+- `make build` – Build the Docker image defined by `Dockerfile`.
+- `make up` – Launch services with Docker Compose.
+- `make test` – Execute the test suite inside the `app` container.
+- `make down` – Stop and remove the Compose services.


### PR DESCRIPTION
## Summary
- create Makefile with helper targets for Docker
- document the Makefile commands in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef69e716c8321a13dd92d873969c6