### PR TITLE
Add local Ollama service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,16 @@ FROM python:3.11-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential \
-        libpq-dev && \
-    rm -rf /var/lib/apt/lists/*
+        libpq-dev \
+        curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl -fsSL https://ollama.com/install.sh | sh
 
 # Install Python dependencies
 RUN pip install --no-cache-dir redis psycopg2-binary
+
+# Pre-download the Quwen model for local serving
+RUN ollama pull qwen2.5:7b-instruct-q4_k_m
 
 # Set work directory
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,5 +31,19 @@ services:
     ports:
       - "8000:8000"
 
+  ollama:
+    build: .
+    command: ["ollama", "serve", "--host", "0.0.0.0", "--context-size", "32768"]
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama:/root/.ollama
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+
 volumes:
   pgdata:
+  ollama:

--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -27,3 +27,30 @@ Stop the services with `Ctrl+C` and remove containers using:
 ```bash
 docker-compose down
 ```
+
+## GPU Requirements for Ollama
+
+Ollama relies on an NVIDIA GPU with at least 4 GB of VRAM. Make sure the
+NVIDIA Container Toolkit is installed so Docker can access the GPU. The
+`ollama` service in `docker-compose.yml` requests a GPU device and exposes port
+`11434` for API access. Start all services with:
+
+```bash
+docker compose up
+```
+
+If GPU access fails, verify that you can run `nvidia-smi` inside a container
+and that Docker is configured with the `--gpus` flag.
+
+## Model Initialization
+
+The Docker image downloads the `qwen2.5:7b-instruct-q4_k_m` model during the
+build step. On first run the `ollama` service starts the model server with a
+32K context window:
+
+```bash
+ollama serve --host 0.0.0.0 --context-size 32768
+```
+
+The downloaded model data is stored in the `ollama` Docker volume so repeated
+runs do not trigger new downloads.


### PR DESCRIPTION
## Summary
- install Ollama and pre-pull qwen model in Dockerfile
- start an Ollama container with GPU and 32k context
- document GPU setup and model initialization

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ef6a4db1c83219a33d4bbccad9fea