### PR TITLE
Fix Ollama pull during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,11 @@ RUN apt-get update && \
 RUN pip install --no-cache-dir redis psycopg2-binary
 
 # Pre-download the Qwen model for local serving
-RUN ollama pull qwen2.5:7b-instruct-q4_k_m
+RUN ollama serve >/tmp/ollama.log 2>&1 & \
+    pid=$! && \
+    sleep 5 && \
+    ollama pull qwen2.5:7b-instruct-q4_k_m && \
+    kill $pid
 
 # Set work directory
 WORKDIR /app

--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -45,8 +45,9 @@ and that Docker is configured with the `--gpus` flag.
 ## Model Initialization
 
 The Docker image downloads the `qwen2.5:7b-instruct-q4_k_m` model during the
-build step. On first run the `ollama` service starts the model server with a
-32K context window:
+build step. The Dockerfile briefly launches `ollama serve` so that `ollama pull`
+can fetch the model. On first run the `ollama` service starts the model server
+with a 32K context window:
 
 ```bash
 ollama serve --host 0.0.0.0 --context-size 32768


### PR DESCRIPTION
## Summary
- start `ollama serve` during build so `ollama pull` succeeds
- document the temporary `ollama serve` usage when building the image

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684eeacf8900832189f88743db2d3112