### PR TITLE
Update docs for finalized CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,39 @@ The system is composed of the following agents:
 
 Agents communicate through short-term and long-term storage mechanisms. The CLI acts as the main control surface, with plans to extend functionality through a Web UI in upcoming versions.
 
+## Command Line Usage
+
+Run the project with the ``writeragents`` command. By default the CLI loads
+``config/local.yaml`` but this can be overridden either with ``--config`` or via
+environment variables.
+
+```bash
+# explicit config path
+writeragents --config config/remote.yaml
+
+# using environment variables
+WRITERAGENTS_CONFIG=config/remote.yaml DATABASE_URL=postgresql://user:pass@host/db \
+REDIS_HOST=redis.example.com writeragents
+```
+
+Environment variables provide a convenient way to change the database and Redis
+connection details without editing configuration files:
+
+- ``WRITERAGENTS_CONFIG`` – default configuration file path when ``--config`` is
+  omitted.
+- ``DATABASE_URL`` – overrides ``storage.database_url`` from the YAML file.
+- ``REDIS_HOST`` – overrides ``storage.redis_host`` from the YAML file.
+
 ## Roadmap
 
 1. Finalize CLI utilities and configuration management.
 2. Introduce a simple Web UI that mirrors CLI features.
 3. Iterate on agent interactions and expand storage options.
+
+## Roadmap Progress
+
+Phase 1 (CLI and configuration management) is complete. Development is now
+focused on the initial Web UI and deeper agent coordination.
 
 Additional documentation is available in the [docs/](docs/) directory.
 

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,6 +1,7 @@
 """Command-line entry point."""
 
 import argparse
+import os
 from typing import Any, Dict, Optional, Tuple
 
 import yaml
@@ -20,18 +21,20 @@ def main(argv: Optional[list[str]] | None = None) -> Tuple[Dict[str, Any], Datab
     parser = argparse.ArgumentParser(description="Interact with WriterAgents")
     parser.add_argument(
         "--config",
-        default="config/local.yaml",
         help="Path to config file",
     )
     args = parser.parse_args(argv)
 
-    config = load_config(args.config)
+    config_path = args.config or os.environ.get("WRITERAGENTS_CONFIG", "config/local.yaml")
+    config = load_config(config_path)
 
     storage_cfg = config.get("storage", {})
-    long_term = DatabaseMemory(url=storage_cfg.get("database_url", "sqlite:///memory.db"))
-    short_term = RedisMemory(host=storage_cfg.get("redis_host", "localhost"))
+    db_url = os.environ.get("DATABASE_URL", storage_cfg.get("database_url", "sqlite:///memory.db"))
+    redis_host = os.environ.get("REDIS_HOST", storage_cfg.get("redis_host", "localhost"))
+    long_term = DatabaseMemory(url=db_url)
+    short_term = RedisMemory(host=redis_host)
 
-    print(f"Using configuration: {args.config}")
+    print(f"Using configuration: {config_path}")
     return config, long_term, short_term
 
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -14,7 +14,7 @@ Storage Layer (Short- & Long-Term Memory)
 Agents (WBA, Consistency Checker, Creativity Assistant, RAG Search, Writer Agent)
 ```
 
-- **Command Interface**: Users initiate and control runs through the CLI, which will later expand into a Web interface.
+- **Command Interface**: Users initiate and control runs through the CLI, which supports configuration files and environment variables. A Web interface is planned for future releases.
 - **Storage Layer**: Provides short-term memory via Redis and long-term memory via SQLite or PostgreSQL.
 - **Agents**: Each agent performs a discrete task in the writing workflow, ensuring consistent world-building, factual continuity, and stylistic creativity.
 

--- a/docs/run_modes.md
+++ b/docs/run_modes.md
@@ -14,5 +14,7 @@ WriterAgents supports two execution modes: **local** and **networked**.
 - Ideal for leveraging larger hosted models.
 - Configure API keys and endpoints in `config/remote.yaml`.
 
-Switch between modes by providing the appropriate configuration file when launching the CLI.
+Launch the application with the ``writeragents`` command. Pass a configuration
+file using ``--config`` or set ``WRITERAGENTS_CONFIG`` in the environment.
+This flag controls which of the modes below is active.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import yaml
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -16,3 +17,17 @@ def test_default_config_loading():
     assert config == expected
     assert db_mem.url == expected['storage']['database_url']
     assert redis_mem.host == expected['storage']['redis_host']
+
+
+def test_env_overrides(monkeypatch):
+    monkeypatch.setenv('WRITERAGENTS_CONFIG', 'config/remote.yaml')
+    monkeypatch.setenv('DATABASE_URL', 'sqlite:///override.db')
+    monkeypatch.setenv('REDIS_HOST', 'example.com')
+
+    config, db_mem, redis_mem = main([])
+    with open('config/remote.yaml') as fh:
+        expected = yaml.safe_load(fh)
+
+    assert config == expected
+    assert db_mem.url == 'sqlite:///override.db'
+    assert redis_mem.host == 'example.com'


### PR DESCRIPTION
## Summary
- document new CLI options and env vars
- note phase 1 completion in roadmap progress
- mention CLI usage in docs
- add env-var override support to CLI
- test env var configuration

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f0ec4d1dc8321a8ec077b6398c866