### PR TITLE
Format code and clean up tests

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -15,7 +15,9 @@ def load_config(path: str) -> Dict[str, Any]:
         return yaml.safe_load(fh) or {}
 
 
-def main(argv: Optional[list[str]] | None = None) -> Tuple[Dict[str, Any], DatabaseMemory, RedisMemory]:
+def main(
+    argv: Optional[list[str]] | None = None,
+) -> Tuple[Dict[str, Any], DatabaseMemory, RedisMemory]:
     """Entry point for the CLI."""
     parser = argparse.ArgumentParser(description="Interact with WriterAgents")
     parser.add_argument(
@@ -28,12 +30,14 @@ def main(argv: Optional[list[str]] | None = None) -> Tuple[Dict[str, Any], Datab
     config = load_config(args.config)
 
     storage_cfg = config.get("storage", {})
-    long_term = DatabaseMemory(url=storage_cfg.get("database_url", "sqlite:///memory.db"))
+    long_term = DatabaseMemory(
+        url=storage_cfg.get("database_url", "sqlite:///memory.db")
+    )
     short_term = RedisMemory(host=storage_cfg.get("redis_host", "localhost"))
 
     print(f"Using configuration: {args.config}")
     return config, long_term, short_term
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/storage/long_term.py
+++ b/storage/long_term.py
@@ -1,7 +1,8 @@
 """Long-term memory using SQLite or PostgreSQL."""
 
+
 class DatabaseMemory:
-    def __init__(self, url='sqlite:///memory.db'):
+    def __init__(self, url="sqlite:///memory.db"):
         self.url = url
         # TODO: initialize database connection
 

--- a/storage/rag_store.py
+++ b/storage/rag_store.py
@@ -7,7 +7,8 @@ class RAGEmbeddingStore:
 
     def _embed(self, text):
         import hashlib
-        digest = hashlib.sha256(text.encode('utf-8')).digest()
+
+        digest = hashlib.sha256(text.encode("utf-8")).digest()
         # return first 8 bytes as ints for deterministic small embedding
         return [b for b in digest[:8]]
 
@@ -21,4 +22,3 @@ class RAGEmbeddingStore:
         self.data.append(record)
         self._next_id += 1
         return record
-

--- a/storage/short_term.py
+++ b/storage/short_term.py
@@ -1,7 +1,8 @@
 """Short-term memory using Redis."""
 
+
 class RedisMemory:
-    def __init__(self, host='localhost', port=6379):
+    def __init__(self, host="localhost", port=6379):
         self.host = host
         self.port = port
         # TODO: initialize Redis connection

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,18 +1,19 @@
 import os
 import sys
-
 import yaml
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
 
-from cli import main
+from cli import main  # noqa: E402
 
 
 def test_default_config_loading():
     config, db_mem, redis_mem = main([])
-    with open('config/local.yaml') as fh:
+    with open("config/local.yaml") as fh:
         expected = yaml.safe_load(fh)
 
     assert config == expected
-    assert db_mem.url == expected['storage']['database_url']
-    assert redis_mem.host == expected['storage']['redis_host']
+    assert db_mem.url == expected["storage"]["database_url"]
+    assert redis_mem.host == expected["storage"]["redis_host"]

--- a/tests/test_wba_archivist.py
+++ b/tests/test_wba_archivist.py
@@ -1,11 +1,12 @@
 import os
 import sys
-import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
 
-from agents.wba.agent import WorldBuildingArchivist
-from storage import RAGEmbeddingStore
+from agents.wba.agent import WorldBuildingArchivist  # noqa: E402
+from storage import RAGEmbeddingStore  # noqa: E402
 
 
 def test_archive_text_stores_record():
@@ -17,4 +18,3 @@ def test_archive_text_stores_record():
     assert record["text"] == "hello world"
     assert isinstance(record["embedding"], list)
     assert len(record["embedding"]) == 8
-


### PR DESCRIPTION
## Summary
- reformat Python codebase with black
- move test imports to the top and remove unused pytest import
- keep path adjustments with `# noqa: E402`

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f0ec7965c8321a137933755a9c696