### PR TITLE
Fix CLI import paths

### DIFF
--- a/writeragents/cli/__init__.py
+++ b/writeragents/cli/__init__.py
@@ -10,7 +10,6 @@ import yaml
 from writeragents.storage.long_term import DatabaseMemory
 from writeragents.storage.short_term import RedisMemory
 from importlib import resources
-import os
 
 
 def load_config(path: str) -> Dict[str, Any]:
@@ -65,12 +64,12 @@ def main(
     short_term = RedisMemory(host=storage_cfg.get("redis_host", "localhost"))
 
     if args.command == "archive":
-        from agents.wba.agent import WorldBuildingArchivist
+        from writeragents.agents.wba.agent import WorldBuildingArchivist
 
         agent = WorldBuildingArchivist()
         agent.archive_text(args.text)
     elif args.command == "write":
-        from agents.writer_agent.agent import WriterAgent
+        from writeragents.agents.writer_agent.agent import WriterAgent
 
         agent = WriterAgent()
         agent.run(args.prompt)


### PR DESCRIPTION
## Summary
- fix double `import os` in CLI module
- import agents via full `writeragents.agents` path

## Testing
- `python -m writeragents --help`
- `python -m writeragents write "Hello"`
- `python -m writeragents archive "hello world"`
- `pytest -q` *(fails: the following arguments are required: command)*

------
https://chatgpt.com/codex/tasks/task_e_684f1cb51db48321af4c614a0d33f2f0