### PR TITLE
Fix CLI tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,12 +4,19 @@ from importlib import resources
 
 import pytest
 
-
 from writeragents.cli import main
+from writeragents.agents.writer_agent.agent import WriterAgent
+from writeragents.agents.wba.agent import WorldBuildingArchivist
 
 
-def test_default_config_loading():
-    config, db_mem, redis_mem = main([])
+def test_default_config_loading(monkeypatch):
+    called = {}
+
+    def fake_archive(self, text):
+        called["text"] = text
+
+    monkeypatch.setattr(WorldBuildingArchivist, "archive_text", fake_archive)
+    config, db_mem, redis_mem = main(["archive", "hello"])
     text = resources.files("writeragents").joinpath("config/local.yaml").read_text()
     expected = yaml.safe_load(text)
 


### PR DESCRIPTION
## Summary
- patch `WorldBuildingArchivist.archive_text` and import missing agents in `tests/test_cli.py`
- make CLI tests exercise the archive command properly

## Testing
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1d7245648321a36b95623fb45e57