### PR TITLE
Add candidate limit for new content types

### DIFF
--- a/tests/test_wba_classification.py
+++ b/tests/test_wba_classification.py
@@ -4,7 +4,7 @@ from writeragents.storage import RAGEmbeddingStore
 
 def test_add_and_search_and_autocreate():
     store = RAGEmbeddingStore()
-    manager = ContentTypeManager(store=store, threshold=0.9)
+    manager = ContentTypeManager(store=store, threshold=0.9, candidate_limit=2)
 
     # Add a type and ensure it is stored
     t1 = manager.add_type("Character")
@@ -16,7 +16,11 @@ def test_add_and_search_and_autocreate():
     assert found["id"] == t1["id"]
     assert len([r for r in store.data if r.get("metadata", {}).get("category") == manager.CATEGORY]) == 1
 
-    # Classify new unrelated type should create a new entry
+    # First use of unknown label should not create a new type
+    assert manager.classify("Location") is None
+    assert len([r for r in store.data if r.get("metadata", {}).get("category") == manager.CATEGORY]) == 1
+
+    # After the second appearance the type is created
     t2 = manager.classify("Location")
     assert t2["text"] == "Location"
     assert len([r for r in store.data if r.get("metadata", {}).get("category") == manager.CATEGORY]) == 2

--- a/writeragents/config/local.yaml
+++ b/writeragents/config/local.yaml
@@ -5,3 +5,5 @@ llm:
 storage:
   database_url: sqlite:///memory.db
   redis_host: localhost
+wba:
+  candidate_limit: 3

--- a/writeragents/config/remote.yaml
+++ b/writeragents/config/remote.yaml
@@ -6,3 +6,5 @@ llm:
 storage:
   database_url: postgres://user:pass@db/writeragents
   redis_host: redis
+wba:
+  candidate_limit: 3


### PR DESCRIPTION
## Summary
- track candidate counts in `ContentTypeManager`
- add `candidate_limit` option to local/remote configs
- create new types only after repeated classification attempts
- update classification tests

## Testing
- `pip install --quiet -r requirements.txt`
- `pip install --quiet -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f22d8e1648321a9c5d77b67e41897