### PR TITLE
Add WBA verification docs to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ WORKDIR /app
 
 # Copy source
 COPY . /app
+# Include WBA sample verification documents
+COPY docs/wba_samples /app/docs/wba_samples
+ENV WBA_DOCS=/app/docs/wba_samples
 
 # Default command
 CMD ["python", "-m", "writeragents"]

--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -11,6 +11,9 @@ docker build -t writeragents .
 ```
 
 This creates an image with Python 3.11, Redis and PostgreSQL client libraries pre-installed.
+It also copies example WBA verification documents to `/app/docs/wba_samples` in
+the container. The `WBA_DOCS` environment variable points to this directory for
+easy reference.
 
 ## Run with Docker Compose
 

--- a/docs/wba_samples/README.md
+++ b/docs/wba_samples/README.md
@@ -1,0 +1,2 @@
+Verification samples for the World Building Archivist (WBA).
+These files are bundled into the Docker image for testing purposes.

--- a/docs/wba_samples/sample1.md
+++ b/docs/wba_samples/sample1.md
@@ -1,0 +1,3 @@
+# Sample WBA Verification Document
+
+This file is used to verify that the Docker image includes the WBA documentation.


### PR DESCRIPTION
## Summary
- add `docs/wba_samples/` with example verification files
- copy the `wba_samples` directory into the Docker image and expose via `WBA_DOCS`
- document presence of verification files in Docker container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2ad43ae883219ac1d9c68c716c05