### PR TITLE
Fix yarn registry URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+rag_store.json

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+npmRegistryServer: "https://registry.yarnpkg.com"


### PR DESCRIPTION
## Summary
- add a `.yarnrc.yml` file so Yarn uses `https://registry.yarnpkg.com`
- ignore the JSON file used by the RAG store

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f27d52bf48321a8ede68e0360fe7b