### PR TITLE
Auto-load sample docs in WBA menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ New commands include::
 
 The ``wba-menu`` command launches an interactive prompt for loading markdown
 files into the archive, searching existing entries, and viewing statistics.
+Selecting option ``1`` now automatically loads the bundled sample documents from
+``docs/wba_samples`` (or the directory specified by the ``WBA_DOCS``
+environment variable). Option ``5`` clears the RAG store so you can start fresh.
 
 When using Docker Compose you can run menu commands from the host with::
 

--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -89,3 +89,7 @@ If the stack is already running with `docker compose up`, swap `run` for
 docker compose exec app python -m writeragents wba-menu
 ```
 
+Option `1` of the menu automatically imports the verification markdown files
+from the directory pointed to by the `WBA_DOCS` environment variable (by
+default `/app/docs/wba_samples`). Option `5` wipes the RAG store.
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 import yaml
 
+import os
+from pathlib import Path
 from importlib import resources
 
 import pytest
@@ -74,9 +76,19 @@ def test_menu_load_dispatch(monkeypatch):
     def fake_load(self, path):
         called["path"] = path
 
-    monkeypatch.setattr(WorldBuildingArchivist, "load_markdown_directory", fake_load)
-    _run_menu(monkeypatch, ["1", "/docs", "0"])
-    assert called["path"] == "/docs"
+    monkeypatch.setattr(
+        WorldBuildingArchivist, "load_markdown_directory", fake_load
+    )
+    _run_menu(monkeypatch, ["1", "0"])
+    sample_dir = os.environ.get(
+        "WBA_DOCS",
+        str(
+            Path(__file__).resolve().parent.parent
+            / "docs"
+            / "wba_samples"
+        ),
+    )
+    assert called["path"] == sample_dir
 
 
 def test_menu_keyword_search(monkeypatch):
@@ -118,3 +130,14 @@ def test_menu_stats(monkeypatch):
     monkeypatch.setattr(WorldBuildingArchivist, "get_candidate_counts", fake_candidates)
     _run_menu(monkeypatch, ["4", "0"])
     assert called == {"stats": True, "cands": True}
+
+
+def test_menu_clear_store(monkeypatch):
+    called = {}
+
+    def fake_clear(self):
+        called["cleared"] = True
+
+    monkeypatch.setattr(WorldBuildingArchivist, "clear_rag_store", fake_clear)
+    _run_menu(monkeypatch, ["5", "0"])
+    assert called == {"cleared": True}

--- a/tests/test_wba_archivist.py
+++ b/tests/test_wba_archivist.py
@@ -14,3 +14,12 @@ def test_archive_text_stores_record():
     assert isinstance(record["embedding"], list)
     assert len(record["embedding"]) == 8
 
+
+def test_clear_rag_store_resets_data():
+    store = RAGEmbeddingStore()
+    wba = WorldBuildingArchivist(store=store)
+    wba.archive_text("text")
+    assert store.data
+    wba.clear_rag_store()
+    assert store.data == []
+

--- a/writeragents/agents/wba/agent.py
+++ b/writeragents/agents/wba/agent.py
@@ -51,6 +51,12 @@ class WorldBuildingArchivist:
         """Return current unresolved type candidate counts."""
         return self.types.get_candidate_counts()
 
+    # ------------------------------------------------------------------
+    def clear_rag_store(self) -> None:
+        """Remove all archived records and reset classification state."""
+        self.store.clear()
+        self.types = ContentTypeManager(store=self.store)
+
     def run(self, context):
         # TODO: implement world building logic
         pass

--- a/writeragents/cli/__init__.py
+++ b/writeragents/cli/__init__.py
@@ -111,12 +111,21 @@ def main(
                 "2) Keyword search\n"
                 "3) Semantic search\n"
                 "4) Show type stats\n"
+                "5) Clear RAG store\n"
                 "0) Exit\n"
                 "Select option: "
             ).strip()
             if choice == "1":
-                path = input("Directory path: ")
-                agent.load_markdown_directory(path)
+                sample_dir = os.environ.get(
+                    "WBA_DOCS",
+                    str(
+                        Path(__file__).resolve().parent.parent.parent
+                        / "docs"
+                        / "wba_samples"
+                    ),
+                )
+                print(f"Loading sample markdown from {sample_dir}")
+                agent.load_markdown_directory(sample_dir)
             elif choice == "2":
                 term = input("Keyword: ")
                 results = agent.search_keyword(term)
@@ -136,6 +145,9 @@ def main(
                 print("Unresolved candidates:")
                 for name, count in candidate_counts.items():
                     print(f"  {name}: {count}")
+            elif choice == "5":
+                agent.clear_rag_store()
+                print("RAG store cleared")
             elif choice == "0":
                 break
     elif args.command == "write":

--- a/writeragents/storage/file_store.py
+++ b/writeragents/storage/file_store.py
@@ -20,3 +20,9 @@ class FileRAGStore(RAGEmbeddingStore):
     def save(self) -> None:
         with open(self.path, "w", encoding="utf-8") as fh:
             json.dump({"data": self.data, "_next_id": self._next_id}, fh)
+
+    def clear(self) -> None:  # pragma: no cover - simple file removal
+        """Delete all records and remove the JSON file if it exists."""
+        super().clear()
+        if os.path.exists(self.path):
+            os.remove(self.path)

--- a/writeragents/storage/rag_store.py
+++ b/writeragents/storage/rag_store.py
@@ -52,3 +52,9 @@ class RAGEmbeddingStore:
                 best_score = score
         return best, best_score
 
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        """Remove all stored records."""
+        self.data = []
+        self._next_id = 1
+


### PR DESCRIPTION
## Summary
- simplify WBA menu option 1 by loading sample docs automatically
- add option 5 to clear the RAG store
- adjust tests for new behaviour
- document automatic loading and clearing in README and docker setup instructions

## Testing
- `pip install -q -r requirements.txt`
- `pip install -e . -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f305c2dbc8321a5155e071a58e237