### PR TITLE
Phase 2: add simple Flask chat UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,17 @@ When using Docker Compose you can run menu commands from the host with::
 
 If the services are already running, use ``docker compose exec app`` instead of ``run``.
 
+To start the Web UI from your host, publish port ``5000`` and run::
+
+    docker compose run --rm -p 5000:5000 app python -m writeragents.web.app
+
+Again, replace ``run`` with ``exec`` if the container is already running.
+
 ## Status
 
 Phase 1 is complete. The project currently provides the CLI utilities and
-configuration management.
+configuration management. A lightweight Web chat interface is also included as
+the starting point for phase 2.
 Run the CLI as shown above. It loads `writeragents/config/local.yaml` by
 default. Use `--config` or the `WRITERAG_CONFIG` environment variable to select
 a different YAML configuration file, such as `writeragents/config/remote.yaml`.
@@ -51,7 +58,11 @@ The project currently relies on the **FRIDA** model for generating text embeddin
 ## Roadmap
 
 1. Finalize CLI utilities and configuration management.
-2. Introduce a simple Web UI that mirrors CLI features.
+2. Introduce a simple Web UI that mirrors CLI features. Launch it with::
+
+       python -m writeragents.web.app
+
+   This opens a minimal chat page at `http://localhost:5000`.
 3. Iterate on agent interactions and expand storage options.
 
 Additional documentation is available in the [docs/](docs/) directory. See

--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -93,3 +93,14 @@ Option `1` of the menu automatically imports the verification markdown files
 from the directory pointed to by the `WBA_DOCS` environment variable (by
 default `/app/docs/wba_samples`). Option `5` wipes the RAG store.
 
+## Running the Web UI
+
+To experiment with the simple chat interface, publish port `5000` and run:
+
+```bash
+docker compose run --rm -p 5000:5000 app python -m writeragents.web.app
+```
+
+If the services are already up, use `docker compose exec app` in place of
+`run`.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyyaml
 redis
 psycopg2-binary
 pytest
+flask

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,10 @@
+from writeragents.web.app import app
+
+
+def test_chat_endpoint():
+    client = app.test_client()
+    resp = client.post('/chat', json={'message': 'hello'})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'Echo:' in data['response']
+

--- a/writeragents/__init__.py
+++ b/writeragents/__init__.py
@@ -1,3 +1,3 @@
 """WriterAgents package."""
 
-__all__ = ["cli", "agents", "storage"]
+__all__ = ["cli", "agents", "storage", "web"]

--- a/writeragents/agents/writer_agent/agent.py
+++ b/writeragents/agents/writer_agent/agent.py
@@ -2,5 +2,10 @@ class WriterAgent:
     """Coordinates other agents and produces the final narrative."""
 
     def run(self, prompt):
-        # TODO: implement story writing workflow
-        pass
+        """Generate a text response for ``prompt``.
+
+        This placeholder implementation simply echoes the prompt back. It
+        allows the CLI and Web UI to provide basic interaction while the
+        full agent workflow is still under development.
+        """
+        return f"Echo: {prompt}"

--- a/writeragents/web/__init__.py
+++ b/writeragents/web/__init__.py
@@ -1,0 +1,5 @@
+"""Simple Flask web interface."""
+
+from .app import app
+
+__all__ = ["app"]

--- a/writeragents/web/app.py
+++ b/writeragents/web/app.py
@@ -1,0 +1,60 @@
+from flask import Flask, jsonify, render_template_string, request
+
+from writeragents.agents.writer_agent.agent import WriterAgent
+
+app = Flask(__name__)
+agent = WriterAgent()
+
+INDEX_HTML = """
+<!doctype html>
+<html>
+<head>
+  <meta charset='utf-8'>
+  <title>WriterAgents Chat</title>
+  <style>
+    body { font-family: sans-serif; margin: 2em; }
+    #log { border: 1px solid #ccc; padding: 10px; height: 300px; overflow-y: scroll; }
+    #input { width: 80%; }
+  </style>
+</head>
+<body>
+  <div id='log'></div>
+  <form id='form'>
+    <input id='input' autocomplete='off'/>
+    <button>Send</button>
+  </form>
+<script>
+const log = document.getElementById('log');
+const form = document.getElementById('form');
+form.onsubmit = async (e) => {
+  e.preventDefault();
+  const text = document.getElementById('input').value;
+  log.innerHTML += `<div><b>You:</b> ${text}</div>`;
+  document.getElementById('input').value = '';
+  const res = await fetch('/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: text })
+  });
+  const data = await res.json();
+  log.innerHTML += `<div><b>Agent:</b> ${data.response}</div>`;
+  log.scrollTop = log.scrollHeight;
+};
+</script>
+</body>
+</html>
+"""
+
+
+@app.route('/')
+def index() -> str:
+    """Return the chat page."""
+    return render_template_string(INDEX_HTML)
+
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    """Return agent response to posted message."""
+    msg = request.json.get('message', '')
+    response = agent.run(msg)
+    return jsonify({'response': response})


### PR DESCRIPTION
## Summary
- provide lightweight Flask web interface for chatting with WriterAgents
- implement a basic echo response in `WriterAgent.run`
- document the chat UI in the README
- add Flask to requirements
- ensure `__all__` exports web package
- test chat endpoint
- explain Docker commands for launching CLI and chat UI

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fc935c1d48321b70929483a9346a2