### PR TITLE
Fix repeated model download during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,9 @@ RUN apt-get update && \
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Pre-download the Qwen model for local serving
-RUN ollama serve >/tmp/ollama.log 2>&1 & \
-    pid=$! && \
-    sleep 5 && \
-    ollama pull qwen2.5:7b-instruct-q4_k_m && \
-    kill $pid
+# Copy runtime helper script for Ollama
+COPY entrypoint_ollama.sh /usr/local/bin/entrypoint_ollama.sh
+RUN chmod +x /usr/local/bin/entrypoint_ollama.sh
 
 # Set work directory
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   ollama:
     build: .
-    command: ["ollama", "serve", "--host", "0.0.0.0", "--context-size", "32768"]
+    entrypoint: ["entrypoint_ollama.sh"]
     ports:
       - "11434:11434"
     volumes:

--- a/entrypoint_ollama.sh
+++ b/entrypoint_ollama.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+MODEL="qwen2.5:7b-instruct-q4_k_m"
+
+# Ensure ollama server is running and model is available
+ollama pull "$MODEL"
+exec ollama serve --host 0.0.0.0 --context-size 32768


### PR DESCRIPTION
## Summary
- add startup script for Ollama service
- copy the helper script into the image
- run Ollama via the new entrypoint so the model is pulled only at runtime

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fd1cb674883219980f7ced466f910