### PR TITLE
Fix runtime warning in web app and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ To start the Web UI from your host, publish port ``5000`` and run::
     docker compose run --rm -p 5000:5000 app python -m writeragents.web.app
 
 Again, replace ``run`` with ``exec`` if the container is already running.
+Then open `http://localhost:5000` in your browser to access the chat interface.
+View the chat logs with ``docker compose logs -f app``.
 
 ## Status
 

--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -104,3 +104,10 @@ docker compose run --rm -p 5000:5000 app python -m writeragents.web.app
 If the services are already up, use `docker compose exec app` in place of
 `run`.
 
+Open `http://localhost:5000` in your browser to access the chat UI. Logs of
+each message appear in the container output, which you can view with:
+
+```bash
+docker compose logs -f app
+```
+

--- a/writeragents/web/__init__.py
+++ b/writeragents/web/__init__.py
@@ -1,5 +1,14 @@
 """Simple Flask web interface."""
 
-from .app import app
+# Lazily import the Flask app so running ``python -m writeragents.web.app``
+# does not trigger a ``RuntimeWarning`` about the module already being in
+# ``sys.modules``.  Importing only when the ``app`` attribute is accessed
+# avoids premature execution when the package is loaded.
+
+def __getattr__(name):
+    if name == "app":
+        from .app import app
+        return app
+    raise AttributeError(name)
 
 __all__ = ["app"]

--- a/writeragents/web/app.py
+++ b/writeragents/web/app.py
@@ -1,8 +1,10 @@
+import logging
 from flask import Flask, jsonify, render_template_string, request
 
 from writeragents.agents.writer_agent.agent import WriterAgent
 
 app = Flask(__name__)
+logging.basicConfig(level=logging.INFO)
 agent = WriterAgent()
 
 INDEX_HTML = """
@@ -56,5 +58,7 @@ def index() -> str:
 def chat():
     """Return agent response to posted message."""
     msg = request.json.get('message', '')
+    app.logger.info("User: %s", msg)
     response = agent.run(msg)
+    app.logger.info("Agent: %s", response)
     return jsonify({'response': response})


### PR DESCRIPTION
## Summary
- avoid importing the web app on package load to remove a Python runtime warning
- log chat messages from the web endpoint
- document the chat URL and how to see logs in README and docker setup guide

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684fd341cf048321b68364399a614f06