### PR TITLE
Add roadmap doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The project currently relies on the **FRIDA** model for generating text embeddin
 5. Expand the WBA with [self-organizing classification](docs/wba_classification.md).
 6. Incorporate a robust [consistency checker](docs/consistency_checker.md).
 7. Build a [story-structure analysis](docs/story_structure.md) module.
+8. See [docs/roadmap.md](docs/roadmap.md) for the full development roadmap, including plans for model integration, dynamic plot structures, and configuration improvements.
 
 Additional documentation is available in the [docs/](docs/) directory.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,35 @@
+# Development Roadmap
+
+This roadmap outlines upcoming milestones for WriterAgents as it evolves from a collection of command-line tools into a fully orchestrated web-based system.
+
+## 1. Model Integration
+- Implement calls to language models using the endpoints defined in the YAML configuration (e.g. `remote.yaml`).
+- Support both local servers like Ollama and remote API services.
+- Replace the placeholder responses in `WriterAgent` and other modules with actual model-generated text.
+
+## 2. Agent Logic
+- Finish the implementations of `CreativityAssistant`, `RAGSearchAgent`, and `WorldBuildingArchivist.run`.
+- Enhance the `ConsistencyChecker` and `StoryStructureAnalyst` with deeper analyses and metrics.
+
+## 3. Memory Layers
+- Complete `DatabaseMemory` and `RedisMemory` to provide long-term and short-term storage.
+- Abstract the storage backend so it can be swapped via configuration.
+
+## 4. Orchestrator
+- Preserve conversation context in memory.
+- Decide which agent to invoke based on the dialogue history.
+- Allow enabling and configuring agents through YAML settings.
+
+## 5. Dynamic Story Structures
+- Extend the story-structure analyst to load narrative templates from configuration instead of a fixed three-act scheme.
+- Let users define their own plot structures and switch between them dynamically.
+
+## 6. Configuration Cleanup
+- Move hard-coded thresholds, limits, and defaults into the YAML files.
+- Expose options in the Web UI to select modes (local vs networked) and tweak agent parameters.
+
+## 7. Tests and Documentation
+- Add test coverage for model integration and storage layers.
+- Document setup for Docker and configuration of custom story structures.
+
+This plan will lead to a more flexible system where key behaviours—such as which plot templates to apply—can be changed without modifying the codebase.


### PR DESCRIPTION
## Summary
- document planned development milestones for WriterAgents
- reference the detailed roadmap from the main README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850609b22d48321b67f82c586b21839