### PR TITLE
Add dependencies and dev extras for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,15 @@ Common development tasks can be run via the provided `Makefile`:
 You can also start the full stack manually::
 
     docker compose up
+
+## Running Tests Locally
+
+Install dependencies in editable mode with the development extras::
+
+    pip install -e .[dev]
+
+Then execute `pytest` from the project root:
+
+    pytest -q
+
+All tests should pass without additional configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,14 @@ description = "Multi-agent storytelling tools"
 readme = "README.md"
 requires-python = ">=3.10"
 
+[project.dependencies]
+pyyaml = "*"
+redis = "*"
+psycopg2-binary = "*"
+flask = "*"
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
 [project.scripts]
 writeragents = "writeragents.cli:main"


### PR DESCRIPTION
## Summary
- specify runtime dependencies in `pyproject.toml`
- add `dev` extras with pytest
- document how to run tests locally in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506579d6f48321946c3f67b620ed5a