### PR TITLE
Add agent flow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ The project currently relies on the **FRIDA** model for generating text embeddin
    This opens a minimal chat page at `http://localhost:5000`.
 3. Iterate on agent interactions and expand storage options.
 4. Add an [orchestrator](docs/orchestrator.md) to direct all agents.
-5. Expand the WBA with [self-organizing classification](docs/wba_classification.md).
-6. Incorporate a robust [consistency checker](docs/consistency_checker.md).
-7. Build a [story-structure analysis](docs/story_structure.md) module.
-8. See [docs/roadmap.md](docs/roadmap.md) for the full development roadmap, including plans for model integration, dynamic plot structures, and configuration improvements.
+5. Review the planned [agent_flow](docs/agent_flow.md) for orchestrating multiple agents.
+6. Expand the WBA with [self-organizing classification](docs/wba_classification.md).
+7. Incorporate a robust [consistency checker](docs/consistency_checker.md).
+8. Build a [story-structure analysis](docs/story_structure.md) module.
+9. See [docs/roadmap.md](docs/roadmap.md) for the full development roadmap, including plans for model integration, dynamic plot structures, and configuration improvements.
 
 Additional documentation is available in the [docs/](docs/) directory.
 

--- a/docs/agent_flow.md
+++ b/docs/agent_flow.md
@@ -1,0 +1,34 @@
+# Agent Flow Design
+
+This document summarizes the planned interaction model for WriterAgents.
+It is based on the architectural analysis from the discussion about roadmap
+item **1.1 Agent flow decisions**.
+
+## Coordinator (Orchestrator)
+The orchestrator receives requests from the CLI or web UI, parses the
+intent, and invokes the appropriate agent. Conversation logs and recent
+context are stored in Redis.
+
+## Memory and Retrieval
+- **Short-term memory**: Redis stores the current dialogue and partial
+  results.
+- **Long-term memory**: SQLite or PostgreSQL archives texts with
+  embeddings, enabling semantic search.
+- **RAGEmbeddingStore**: provides similarity search to fetch relevant
+  passages when the context exceeds the 32k token limit of the LLM.
+
+## Execution Flow
+1. **Pipeline**: complex tasks can chain agents in a fixed order,
+   for example `WriterAgent -> ConsistencyChecker -> CreativityAssistant`.
+2. **Self-Critique Loop**: the writer agent may repeatedly call the
+   consistency checker (and optionally the creativity assistant) until
+   the output meets quality standards.
+3. **Sliding Context Window**: long inputs are broken into segments, with
+   summaries stored in memory so agents can work within the context limit.
+
+## Hardware Limitations
+The target machine uses a 4 GB VRAM GPU and 32 GB of RAM. Running a
+quantized model such as `qwen2.5:7b-instruct-q4_k_m` keeps GPU memory
+usage manageable. Embedding operations are batch processed to avoid
+excessive RAM consumption.
+

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,7 @@ This roadmap outlines upcoming milestones for WriterAgents as it evolves from a 
 - Replace the placeholder responses in `WriterAgent` and other modules with actual model-generated text.
 
 ## 1.1 Agent flow decisions
-- Choose from different agent flow strategies such as pipelineg agents, sliding context window, Memory-Enhanced Agents, Coordinator + Workers, Self-Critique Loop and others based on hardware limitations (Lenovo P1 Gen2 32 GB Ram Nvidia Quaddro 1000)
+The agent interactions combine several patterns: pipeline processing, a self-critique loop and a sliding context window. They are coordinated by the orchestrator and respect the limitations of a Lenovo P1 Gen2 laptop with 32 GB RAM and a Quadro 1000 GPU. See [agent_flow.md](agent_flow.md) for the detailed flow description.
 
 ## 2. Agent Logic
 - Finish the implementations of `CreativityAssistant`, `RAGSearchAgent`, and `WorldBuildingArchivist.run`.


### PR DESCRIPTION
## Summary
- document overall agent workflow in a new file
- link to the new doc from the roadmap
- reference the agent flow doc in README

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_685081ab0c78832196d8e7565e3936a6