### PR TITLE
Implement LLM client and use it in WriterAgent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ redis
 psycopg2-binary
 pytest
 flask
+requests

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,10 +1,12 @@
 from writeragents.web.app import app
+from writeragents.llm.client import LLMClient
 
 
-def test_chat_endpoint():
+def test_chat_endpoint(monkeypatch):
+    monkeypatch.setattr(LLMClient, 'generate', lambda self, prompt: 'result')
     client = app.test_client()
     resp = client.post('/chat', json={'message': 'hello'})
     assert resp.status_code == 200
     data = resp.get_json()
-    assert 'Echo:' in data['response']
+    assert data['response'] == 'result'
 

--- a/writeragents/agents/writer_agent/agent.py
+++ b/writeragents/agents/writer_agent/agent.py
@@ -1,11 +1,19 @@
+"""Writer agent that delegates text generation to an LLM service."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from writeragents.llm import LLMClient
+
+
 class WriterAgent:
     """Coordinates other agents and produces the final narrative."""
 
-    def run(self, prompt):
-        """Generate a text response for ``prompt``.
+    def __init__(self, llm_client: Optional[LLMClient] = None) -> None:
+        self.llm = llm_client or LLMClient()
 
-        This placeholder implementation simply echoes the prompt back. It
-        allows the CLI and Web UI to provide basic interaction while the
-        full agent workflow is still under development.
-        """
-        return f"Echo: {prompt}"
+    # ------------------------------------------------------------------
+    def run(self, prompt: str) -> str:
+        """Generate a text response for ``prompt`` using the LLM."""
+        return self.llm.generate(prompt)

--- a/writeragents/llm/__init__.py
+++ b/writeragents/llm/__init__.py
@@ -1,0 +1,5 @@
+"""LLM utilities and client."""
+
+from .client import LLMClient
+
+__all__ = ["LLMClient"]

--- a/writeragents/llm/client.py
+++ b/writeragents/llm/client.py
@@ -1,0 +1,55 @@
+"""Client for interacting with a language model service."""
+from __future__ import annotations
+
+import os
+from importlib import resources
+from typing import Any, Dict, Optional
+
+import requests
+
+from writeragents.cli import load_config
+
+
+class LLMClient:
+    """Simple HTTP client for OpenAI-compatible endpoints."""
+
+    def __init__(
+        self,
+        endpoint: Optional[str] = None,
+        model: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ) -> None:
+        if endpoint is None or model is None or api_key is None:
+            cfg = self._load_default_config()
+            endpoint = endpoint or cfg.get("endpoint")
+            model = model or cfg.get("model")
+            api_key = api_key or cfg.get("api_key")
+        self.endpoint = str(endpoint).rstrip("/")
+        self.model = model
+        self.api_key = api_key
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _load_default_config() -> Dict[str, Any]:
+        cfg_path = os.environ.get(
+            "WRITERAG_CONFIG",
+            str(resources.files("writeragents").joinpath("config/local.yaml")),
+        )
+        cfg = load_config(cfg_path)
+        return cfg.get("llm", {})
+
+    # ------------------------------------------------------------------
+    def generate(self, prompt: str) -> str:
+        """Return model output for ``prompt``."""
+        url = f"{self.endpoint}/chat/completions"
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        payload = {"model": self.model, "messages": [{"role": "user", "content": prompt}]}
+        resp = requests.post(url, json=payload, headers=headers, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        choices = data.get("choices", [])
+        if choices:
+            return choices[0].get("message", {}).get("content", "")
+        return ""


### PR DESCRIPTION
## Summary
- implement a simple HTTP client for language model endpoints
- integrate WriterAgent with the LLM client
- adapt web tests to stub LLM output
- add `requests` dependency

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68510ac8b3508321b41ba11451c56335