### PR TITLE
Refactor multiline SQL creation

### DIFF
--- a/writeragents/storage/long_term.py
+++ b/writeragents/storage/long_term.py
@@ -26,7 +26,11 @@ class DatabaseMemory:
     def _ensure_table(self) -> None:
         cur = self.conn.cursor()
         cur.execute(
-            "CREATE TABLE IF NOT EXISTS memory (id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT)"
+            (
+                "CREATE TABLE IF NOT EXISTS memory ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "data TEXT)"
+            )
         )
         self.conn.commit()
 


### PR DESCRIPTION
## Summary
- split long SQL creation statement in `DatabaseMemory._ensure_table`
- keep lines under 88 chars

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68516a4a27908321b4d91c343016d782