### PR TITLE
Add context manager to DatabaseMemory

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -25,7 +25,7 @@ def test_redis_memory(monkeypatch):
 
 def test_database_memory(tmp_path):
     db_path = tmp_path / "mem.db"
-    mem = DatabaseMemory(url=f"sqlite:///{db_path}")
-    mem.store("hello")
-    rows = mem.fetch("SELECT data FROM memory")
-    assert rows[0][0] == "hello"
+    with DatabaseMemory(url=f"sqlite:///{db_path}") as mem:
+        mem.store("hello")
+        rows = mem.fetch("SELECT data FROM memory")
+        assert rows[0][0] == "hello"

--- a/writeragents/storage/long_term.py
+++ b/writeragents/storage/long_term.py
@@ -35,6 +35,25 @@ class DatabaseMemory:
         self.conn.commit()
 
     # ------------------------------------------------------------------
+    def close(self) -> None:
+        """Close the underlying database connection."""
+        self.conn.close()
+
+    # ------------------------------------------------------------------
+    def __enter__(self) -> "DatabaseMemory":
+        """Return ``self`` when entering a ``with`` block."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: Any | None,
+    ) -> None:
+        """Close the connection when exiting a ``with`` block."""
+        self.close()
+
+    # ------------------------------------------------------------------
     def fetch(self, query: str, *params: Any) -> list[tuple]:
         """Return rows matching ``query``."""
         cur = self.conn.cursor()


### PR DESCRIPTION
## Summary
- let `DatabaseMemory` clean up database connections via `close()`
- implement `__enter__`/`__exit__` for context manager support
- update `test_memory` to use the new context manager

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68516b8aeca48321be1942054a537865