### PR TITLE
Add Redis port and DB options

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,8 @@ def test_default_config_loading(monkeypatch):
     assert config == expected
     assert db_mem.url == expected["storage"]["database_url"]
     assert redis_mem.host == expected["storage"]["redis_host"]
+    assert redis_mem.port == expected["storage"]["redis_port"]
+    assert redis_mem.db == expected["storage"]["redis_db"]
 
 
 def test_write_command_dispatch(monkeypatch):
@@ -42,7 +44,11 @@ def test_write_command_dispatch(monkeypatch):
 def test_config_option_parsing(tmp_path, monkeypatch):
     cfg = tmp_path / "cfg.yaml"
     cfg.write_text(
-        "storage:\n  database_url: sqlite:///tmp.db\n  redis_host: otherhost\n"
+        "storage:\n"
+        "  database_url: sqlite:///tmp.db\n"
+        "  redis_host: otherhost\n"
+        "  redis_port: 6380\n"
+        "  redis_db: 2\n"
     )
 
     called = {}
@@ -62,6 +68,8 @@ def test_config_option_parsing(tmp_path, monkeypatch):
     assert config["storage"]["database_url"] == "sqlite:///tmp.db"
     assert db_mem.url == "sqlite:///tmp.db"
     assert redis_mem.host == "otherhost"
+    assert redis_mem.port == 6380
+    assert redis_mem.db == 2
 
 
 def test_candidate_limit_default(monkeypatch):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -20,7 +20,24 @@ def test_redis_memory(monkeypatch):
     mem = RedisMemory()
     mem.set("a", "1")
     assert mem.get("a") == "1"
-    assert mem.client.kw["host"] == "localhost"
+    assert mem.client.kw == {"host": "localhost", "port": 6379, "db": 0}
+
+
+def test_redis_memory_custom(monkeypatch):
+    class FakeRedis:
+        def __init__(self, host="localhost", port=6379, db=0):
+            self.kw = {"host": host, "port": port, "db": db}
+            self.store = {}
+
+        def get(self, key):
+            return self.store.get(key)
+
+        def set(self, key, value):
+            self.store[key] = value
+
+    monkeypatch.setattr(redis, "Redis", FakeRedis)
+    mem = RedisMemory(host="h", port=6380, db=2)
+    assert mem.client.kw == {"host": "h", "port": 6380, "db": 2}
 
 
 def test_database_memory(tmp_path):

--- a/writeragents/cli/__init__.py
+++ b/writeragents/cli/__init__.py
@@ -81,7 +81,11 @@ def main(
     long_term = DatabaseMemory(
         url=storage_cfg.get("database_url", "sqlite:///memory.db")
     )
-    short_term = RedisMemory(host=storage_cfg.get("redis_host", "localhost"))
+    short_term = RedisMemory(
+        host=storage_cfg.get("redis_host", "localhost"),
+        port=int(storage_cfg.get("redis_port", 6379)),
+        db=int(storage_cfg.get("redis_db", 0)),
+    )
     candidate_limit = int(wba_cfg.get("candidate_limit", 3))
     classification_threshold = float(wba_cfg.get("classification_threshold", 0.8))
     story_cfg = config.get("story_structure", {})

--- a/writeragents/config/local.yaml
+++ b/writeragents/config/local.yaml
@@ -5,6 +5,8 @@ llm:
 storage:
   database_url: sqlite:///memory.db
   redis_host: localhost
+  redis_port: 6379
+  redis_db: 0
 wba:
   candidate_limit: 3
   classification_threshold: 0.8

--- a/writeragents/config/remote.yaml
+++ b/writeragents/config/remote.yaml
@@ -6,6 +6,8 @@ llm:
 storage:
   database_url: postgres://user:pass@db/writeragents
   redis_host: redis
+  redis_port: 6379
+  redis_db: 0
 wba:
   candidate_limit: 3
   classification_threshold: 0.8

--- a/writeragents/storage/short_term.py
+++ b/writeragents/storage/short_term.py
@@ -11,6 +11,7 @@ class RedisMemory:
     def __init__(self, host: str = "localhost", port: int = 6379, db: int = 0) -> None:
         self.host = host
         self.port = port
+        self.db = db
         self.client = redis.Redis(host=host, port=port, db=db)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- provide `redis_port` and `redis_db` defaults in sample configs
- expose port and DB fields when creating `RedisMemory`
- pass new options through CLI
- test that CLI and memory honor these options

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68516cc7e69083219aae7c98f3b85559