### PR TITLE
Add endpoints for sample loading and clearing store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 *.pyc
 rag_store.json
+memory.db
+tmp.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && \
 
 # Install Python dependencies
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --root-user-action=ignore \
+    --disable-pip-version-check -r requirements.txt
 
 # Copy runtime helper script for Ollama
 COPY entrypoint_ollama.sh /usr/local/bin/entrypoint_ollama.sh

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,5 +1,6 @@
 from writeragents.web.app import app
 from writeragents.llm.client import LLMClient
+from writeragents.agents.wba.agent import WorldBuildingArchivist
 
 
 def test_chat_endpoint(monkeypatch):
@@ -9,4 +10,33 @@ def test_chat_endpoint(monkeypatch):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data['response'] == 'result'
+
+
+def test_load_samples_endpoint(monkeypatch):
+    called = {}
+
+    def fake_load(self, path):
+        called['path'] = path
+
+    monkeypatch.setattr(WorldBuildingArchivist, 'load_markdown_directory', fake_load)
+    monkeypatch.setenv('WBA_DOCS', '/tmp/docs')
+    client = app.test_client()
+    resp = client.get('/load-samples')
+    assert resp.status_code == 200
+    assert called['path'] == '/tmp/docs'
+    assert resp.get_json()['message'] == 'Loaded'
+
+
+def test_clear_store_endpoint(monkeypatch):
+    called = {}
+
+    def fake_clear(self):
+        called['cleared'] = True
+
+    monkeypatch.setattr(WorldBuildingArchivist, 'clear_rag_store', fake_clear)
+    client = app.test_client()
+    resp = client.get('/clear-store')
+    assert resp.status_code == 200
+    assert called == {'cleared': True}
+    assert resp.get_json()['message'] == 'Cleared'
 


### PR DESCRIPTION
## Summary
- allow loading bundled markdown and clearing the store from the web UI
- wire buttons on the HTML page to these new endpoints
- test `/load-samples` and `/clear-store` routes
- suppress pip warnings when building Docker image

## Testing
- `pip install -q --disable-pip-version-check --root-user-action=ignore -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68516ec804f08321b4be5d1044a3bf83