### PR TITLE
Enable web UI with docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,5 @@ COPY docs/wba_samples /app/docs/wba_samples
 ENV WBA_DOCS=/app/docs/wba_samples
 
 # Default command
-CMD ["python", "-m", "writeragents"]
+EXPOSE 5000
+CMD ["python", "-m", "writeragents.web.app"]

--- a/README.md
+++ b/README.md
@@ -24,11 +24,10 @@ When using Docker Compose you can run menu commands from the host with::
 
 If the services are already running, use ``docker compose exec app`` instead of ``run``.
 
-To start the Web UI from your host, publish port ``5000`` and run::
+To launch the Web UI simply run::
 
-    docker compose run --rm -p 5000:5000 app python -m writeragents.web.app
+    docker compose up -d
 
-Again, replace ``run`` with ``exec`` if the container is already running.
 Then open `http://localhost:5000` in your browser to access the chat interface.
 The page provides **Load samples** and **Clear store** buttons. Clicking
 ``Load samples`` sends a request to ``/load-samples`` which imports the
@@ -76,11 +75,12 @@ The project currently relies on the **FRIDA** model for generating text embeddin
 The complete development plan lives in [docs/roadmap.md](docs/roadmap.md).
 Current progress is tracked in [docs/progress.md](docs/progress.md).
 
-Launch the minimal Web UI with::
+Launch the minimal Web UI locally with::
 
     python -m writeragents.web.app
 
-This opens a chat page at `http://localhost:5000`.
+Or run ``docker compose up -d`` to start it in a container. Both open a chat
+page at `http://localhost:5000`.
 
 Additional documentation is available in the [docs/](docs/) directory,
 including the current [progress report](docs/progress.md).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,17 +19,18 @@ services:
 
   app:
     build: .
-    command: ["python", "-m", "writeragents"]
+    command: ["python", "-m", "writeragents.web.app"]
     volumes:
       - .:/app
     environment:
       DATABASE_URL: postgresql://writer:writerpass@postgres:5432/writerdb
       REDIS_HOST: redis
+      PORT: 5000
     depends_on:
       - postgres
       - redis
     ports:
-      - "8000:8000"
+      - "5000:5000"
 
   ollama:
     build: .

--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -95,14 +95,11 @@ default `/app/docs/wba_samples`). Option `5` wipes the RAG store.
 
 ## Running the Web UI
 
-To experiment with the simple chat interface, publish port `5000` and run:
+Start all services, including the chat interface, with:
 
 ```bash
-docker compose run --rm -p 5000:5000 app python -m writeragents.web.app
+docker compose up -d
 ```
-
-If the services are already up, use `docker compose exec app` in place of
-`run`.
 
 Open `http://localhost:5000` in your browser to access the chat UI. The page
 includes **Load samples** and **Clear store** buttons. These call the


### PR DESCRIPTION
## Summary
- expose port 5000 and run the Flask app by default
- launch the web UI service via docker compose
- document the new startup process

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517284b5ec8321bbcedf840f34e6b2