### PR TITLE
Update default LLM configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ Phase 1 is complete. The project currently provides the CLI utilities and
 configuration management. A lightweight Web chat interface is also included as
 the starting point for phase 2.
 Run the CLI as shown above. It loads `writeragents/config/local.yaml` by
-default. Use `--config` or the `WRITERAG_CONFIG` environment variable to select
-a different YAML configuration file, such as `writeragents/config/remote.yaml`.
-The configuration also lets you define custom story templates under the
-`story_structure` section. See [docs/story_structure.md](docs/story_structure.md)
-for details.
+default. That file targets the ``ollama`` service at
+``http://ollama:11434`` and uses the ``qwen2.5:7b-instruct-q4_k_m`` model.
+Use ``--config`` or the ``WRITERAG_CONFIG`` environment variable to select a
+different YAML configuration file, such as
+`writeragents/config/remote.yaml`. The configuration also lets you define
+custom story templates under the ``story_structure`` section. See
+[docs/story_structure.md](docs/story_structure.md) for details.
 
 ## Architecture
 

--- a/docs/docker_setup.md
+++ b/docs/docker_setup.md
@@ -23,6 +23,10 @@ Use `docker compose` to start PostgreSQL, Redis and the application container:
 docker compose up
 ```
 
+The default configuration file loaded in the `app` container points the
+Orchestrator to the ``ollama`` service at ``http://ollama:11434`` and uses the
+``qwen2.5:7b-instruct-q4_k_m`` model.
+
 The application mounts the project directory for live editing. PostgreSQL data is persisted in the `pgdata` volume.
 
 Stop the services with `Ctrl+C` and remove containers using:

--- a/writeragents/config/local.yaml
+++ b/writeragents/config/local.yaml
@@ -1,7 +1,7 @@
 # Configuration for local mode
 llm:
-  endpoint: http://localhost:8000
-  model: local-model
+  endpoint: http://ollama:11434
+  model: qwen2.5:7b-instruct-q4_k_m
 storage:
   database_url: sqlite:///memory.db
   redis_host: localhost


### PR DESCRIPTION
## Summary
- update `writeragents/config/local.yaml` to use the qwen2.5 model with the ollama endpoint
- document the default endpoint/model in README and docker setup guide

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517ac68e5483219ff92b324b9fa74a