### PR TITLE
Improve LLMClient error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ Install dependencies from PyPI and enable editable mode::
     pip install -r requirements.txt
     pip install -e .[dev]
 
+If package downloads fail with a network access error, see
+[docs/network_access.md](docs/network_access.md) for troubleshooting tips.
+
 Then execute `pytest` from the project root:
 
     pytest -q

--- a/docs/network_access.md
+++ b/docs/network_access.md
@@ -1,0 +1,24 @@
+# Network Troubleshooting
+
+If `pip install` fails with a message like:
+
+```
+Some requests were blocked due to network access restrictions. Consider granting access in environment settings.
+    files.pythonhosted.org: via pip install and other commands
+```
+
+make sure the environment allows outgoing HTTPS requests to `files.pythonhosted.org`.
+You can also set the package index explicitly:
+
+```bash
+pip install --index-url https://pypi.org/simple -r requirements.txt
+```
+
+Or configure `pip.conf` so the index is always set:
+
+```
+[global]
+index-url = https://pypi.org/simple
+```
+
+With access enabled and the index configured, package downloads should succeed.

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -64,7 +64,9 @@ def test_llmclient_error(monkeypatch, caplog):
 
     monkeypatch.setattr(requests, 'post', fake_post)
     client = LLMClient(endpoint='http://example.com/v1', model='gpt', api_key='k')
+    log: list[str] = []
     with caplog.at_level(logging.ERROR):
-        result = client.generate('hi')
+        result = client.generate('hi', log=log)
     assert result == ''
     assert any('fail' in m for m in caplog.messages)
+    assert log == ['prompt: hi', 'error: fail']

--- a/writeragents/llm/client.py
+++ b/writeragents/llm/client.py
@@ -46,7 +46,8 @@ class LLMClient:
         """Return model output for ``prompt`` using the configured endpoint.
 
         If ``log`` is provided, the prompt and final response are appended to
-        that list for inspection.
+        that list for inspection. On request failures, an empty string is
+        returned and the error is added to ``log``.
         """
 
         logger.info("LLM prompt: %s", prompt)
@@ -73,6 +74,8 @@ class LLMClient:
             data = resp.json()
         except (requests.RequestException, ValueError) as exc:
             logger.error("LLM request failed: %s", exc)
+            if log is not None:
+                log.append(f"error: {exc}")
             return ""
         if "choices" in data:
             choices = data.get("choices", [])


### PR DESCRIPTION
## Summary
- append a log entry on LLMClient request failures
- check log output in the failing request test
- document the error logging behavior in `generate`
- add troubleshooting guide for network access

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68518f80bc0083219357c3b2cbbf211e