### PR TITLE
Remove Type/Era support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ New commands include::
     python -m writeragents wba-menu
 
 The ``wba-menu`` command launches an interactive prompt for loading markdown
-files into the archive, searching existing entries, and viewing statistics.
-Selecting option ``1`` now automatically loads the bundled sample documents from
-``docs/wba_samples`` (or the directory specified by the ``WBA_DOCS``
-environment variable). Option ``5`` clears the RAG store so you can start fresh.
+files into the archive or searching existing entries. Selecting option ``1``
+loads the bundled sample documents from ``docs/wba_samples`` (or the directory
+specified by the ``WBA_DOCS`` environment variable). Option ``4`` clears the RAG
+store so you can start fresh.
 
 When using Docker Compose you can run menu commands from the host with::
 

--- a/docs/wba_classification.md
+++ b/docs/wba_classification.md
@@ -14,11 +14,11 @@ See the `ContentTypeManager` in `writeragents/agents/wba/classification.py` for 
 
 ## Faceted classification
 
-Beyond simple content types the archivist can track arbitrary **facets** such as
-`type` or `era`. Each facet is handled by a dedicated `ContentTypeManager`
-instance within ``FacetManager``. When a facet value is seen often enough it is
-saved as a meta-document with ``{"category": "facet-<name>"}``. Future archives
-then store the normalized value in the chunk metadata.
+Beyond simple content types the archivist can track arbitrary **facets**. Each
+facet is handled by a dedicated `ContentTypeManager` instance within
+``FacetManager``. When a facet value is seen often enough it is saved as a
+meta-document with ``{"category": "facet-<name>"}``. Future archives then store
+the normalized value in the chunk metadata.
 
 ## Configuration
 
@@ -32,10 +32,3 @@ wba:
 
 Adjust these values to tune how aggressively new types are created.
 
-## Automatic type extraction
-
-When loading Markdown files or handling multi paragraph input the archivist
-splits text into blocks separated by blank lines. Each block is analyzed
-semantically: the most frequent non‑stopword becomes the candidate type name.
-This allows a single file to yield multiple categorized records without relying
-on headings or file names.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -210,23 +210,6 @@ def test_menu_semantic_search(monkeypatch):
     assert called["text"] == "hi"
 
 
-def test_menu_stats(monkeypatch):
-    called = {}
-
-    def fake_stats(self):
-        called["stats"] = True
-        return {}
-
-    def fake_candidates(self):
-        called["cands"] = True
-        return {}
-
-    monkeypatch.setattr(WorldBuildingArchivist, "get_type_statistics", fake_stats)
-    monkeypatch.setattr(WorldBuildingArchivist, "get_candidate_counts", fake_candidates)
-    _run_menu(monkeypatch, ["4", "0"])
-    assert called == {"stats": True, "cands": True}
-
-
 def test_menu_clear_store(monkeypatch):
     called = {}
 
@@ -234,5 +217,5 @@ def test_menu_clear_store(monkeypatch):
         called["cleared"] = True
 
     monkeypatch.setattr(WorldBuildingArchivist, "clear_rag_store", fake_clear)
-    _run_menu(monkeypatch, ["5", "0"])
+    _run_menu(monkeypatch, ["4", "0"])
     assert called == {"cleared": True}

--- a/tests/test_wba_archivist.py
+++ b/tests/test_wba_archivist.py
@@ -24,13 +24,6 @@ def test_clear_rag_store_resets_data():
     assert store.data == []
 
 
-def test_run_assigns_semantic_type():
-    store = RAGEmbeddingStore()
-    wba = WorldBuildingArchivist(store=store, candidate_limit=1)
-    msg = wba.run("Рыцари охраняют замок")
-    assert msg == "Archived"
-    rec = store.data[-1]
-    assert rec["metadata"]["type"] == "Рыцари"
 
 
 
@@ -42,9 +35,7 @@ def test_load_markdown_directory_multi_paragraph(tmp_path):
         encoding="utf-8",
     )
     store = RAGEmbeddingStore()
-    wba = WorldBuildingArchivist(store=store, candidate_limit=1)
+    wba = WorldBuildingArchivist(store=store)
     wba.load_markdown_directory(str(tmp_path))
-    types = [r["metadata"]["type"] for r in store.data if "type" in r.get("metadata", {})]
-    assert "Рыцари" in types
-    assert "Торговля" in types
+    assert len(store.data) == 2
 

--- a/tests/test_wba_classification.py
+++ b/tests/test_wba_classification.py
@@ -33,14 +33,14 @@ def test_facet_manager_autocreate():
     facets = FacetManager(store=store, threshold=0.9, candidate_limit=2)
 
     # First sighting does not create a record
-    assert facets.classify("era", "Bronze Age") is None
-    assert not [r for r in store.data if r.get("metadata", {}).get("category") == "facet-era"]
+    assert facets.classify("group", "Bronze Age") is None
+    assert not [r for r in store.data if r.get("metadata", {}).get("category") == "facet-group"]
 
     # Second sighting triggers creation
-    rec = facets.classify("era", "Bronze Age")
+    rec = facets.classify("group", "Bronze Age")
     assert rec["text"] == "Bronze Age"
-    assert rec["metadata"]["category"] == "facet-era"
-    assert len([r for r in store.data if r.get("metadata", {}).get("category") == "facet-era"]) == 1
+    assert rec["metadata"]["category"] == "facet-group"
+    assert len([r for r in store.data if r.get("metadata", {}).get("category") == "facet-group"]) == 1
 
 
 def test_classification_logging(caplog):

--- a/writeragents/cli/__init__.py
+++ b/writeragents/cli/__init__.py
@@ -133,8 +133,7 @@ def main(
                 "1) Load Markdown directory\n"
                 "2) Keyword search\n"
                 "3) Semantic search\n"
-                "4) Show type stats\n"
-                "5) Clear RAG store\n"
+                "4) Clear RAG store\n"
                 "0) Exit\n"
                 "Select option: "
             ).strip()
@@ -160,15 +159,6 @@ def main(
                 if res:
                     print(res["text"])
             elif choice == "4":
-                type_counts = agent.get_type_statistics()
-                candidate_counts = agent.get_candidate_counts()
-                print("Content types:")
-                for name, count in type_counts.items():
-                    print(f"  {name}: {count}")
-                print("Unresolved candidates:")
-                for name, count in candidate_counts.items():
-                    print(f"  {name}: {count}")
-            elif choice == "5":
                 agent.clear_rag_store()
                 print("RAG store cleared")
             elif choice == "0":


### PR DESCRIPTION
## Summary
- drop semantic type extraction and related stats
- adjust CLI menu, docs and tests
- update classification docs for new dynamic facets

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685197f4b78c83218cd51709d64bf452