### PR TITLE
Add basic data models

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ processes markdown files and stores extracted knowledge in databases.
 1. Install dependencies:
 
 ```bash
-pip install -r requirements.txt
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
 ```
 
 2. Copy the example environment file and adjust values as needed:

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,4 @@
+from .entities import Entity
+from .relationships import Relationship
+
+__all__ = ["Entity", "Relationship"]

--- a/src/models/entities.py
+++ b/src/models/entities.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class Entity(BaseModel):
+    """Represents an extracted entity."""
+
+    id: Optional[str] = None
+    name: str
+    type: str
+    description: Optional[str] = None
+    source_file: str
+    chunk_id: str
+    confidence: float

--- a/src/models/relationships.py
+++ b/src/models/relationships.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class Relationship(BaseModel):
+    """Represents a relationship between entities."""
+
+    source_entity: str
+    target_entity: str
+    relation_type: str
+    description: Optional[str] = None
+    confidence: float

--- a/tests/test_models/test_data_models.py
+++ b/tests/test_models/test_data_models.py
@@ -1,0 +1,62 @@
+from pydantic import ValidationError
+
+from src.models.entities import Entity
+from src.models.relationships import Relationship
+
+
+def test_entity_model_fields():
+    entity = Entity(
+        id="1",
+        name="John",
+        type="person",
+        description="Hero",
+        source_file="story.md",
+        chunk_id="c1",
+        confidence=0.95,
+    )
+
+    assert entity.id == "1"
+    assert entity.name == "John"
+    assert entity.type == "person"
+    assert entity.description == "Hero"
+    assert entity.source_file == "story.md"
+    assert entity.chunk_id == "c1"
+    assert entity.confidence == 0.95
+
+
+def test_entity_optional_fields_defaults():
+    entity = Entity(
+        name="Sword",
+        type="object",
+        source_file="story.md",
+        chunk_id="c2",
+        confidence=0.8,
+    )
+
+    assert entity.id is None
+    assert entity.description is None
+
+
+def test_relationship_model_fields():
+    rel = Relationship(
+        source_entity="John",
+        target_entity="Mary",
+        relation_type="friend",
+        description="Childhood friends",
+        confidence=0.9,
+    )
+
+    assert rel.source_entity == "John"
+    assert rel.target_entity == "Mary"
+    assert rel.relation_type == "friend"
+    assert rel.description == "Childhood friends"
+    assert rel.confidence == 0.9
+
+
+def test_relationship_missing_required():
+    try:
+        Relationship(source_entity="A", target_entity="B")
+    except ValidationError:
+        pass
+    else:
+        raise AssertionError("ValidationError not raised")


### PR DESCRIPTION
## Summary
- implement `Entity` and `Relationship` pydantic models
- expose models from the package
- add unit tests for the data models
- clarify dependency installation steps in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851cad6b2a883218d9dcfc9734231c0