### PR TITLE
Fix data models and chunk overlap

### DIFF
--- a/src/models/entities.py
+++ b/src/models/entities.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -12,6 +12,9 @@ class Entity(BaseModel):
     name: str
     type: str
     description: Optional[str] = None
+    mentions: List[str] = []
+    confidence: float
     source_file: str
     chunk_id: str
-    confidence: float
+    source_chunk: str
+    context: str

--- a/src/models/relationships.py
+++ b/src/models/relationships.py
@@ -13,3 +13,4 @@ class Relationship(BaseModel):
     relation_type: str
     description: Optional[str] = None
     confidence: float
+    source_text: str

--- a/src/utils/chunking.py
+++ b/src/utils/chunking.py
@@ -104,8 +104,8 @@ def _add_overlap(chunks: List[str], overlap_tokens: int, tokenizer) -> List[str]
         prev_tokens = tokenizer.encode(prev_chunk)
         if len(prev_tokens) >= overlap_tokens:
             overlap_text = tokenizer.decode(prev_tokens[-overlap_tokens:])
-            new_chunk = overlap_text + current_chunk
+            new_chunk = overlap_text + " " + current_chunk
         else:
-            new_chunk = prev_chunk + current_chunk
+            new_chunk = prev_chunk + " " + current_chunk
         overlapped.append(new_chunk)
     return overlapped

--- a/tests/test_models/test_data_models.py
+++ b/tests/test_models/test_data_models.py
@@ -10,8 +10,11 @@ def test_entity_model_fields():
         name="John",
         type="person",
         description="Hero",
+        mentions=["John", "Johnny"],
         source_file="story.md",
         chunk_id="c1",
+        source_chunk="John went to the market.",
+        context="...John went to the...",
         confidence=0.95,
     )
 
@@ -19,8 +22,11 @@ def test_entity_model_fields():
     assert entity.name == "John"
     assert entity.type == "person"
     assert entity.description == "Hero"
+    assert entity.mentions == ["John", "Johnny"]
     assert entity.source_file == "story.md"
     assert entity.chunk_id == "c1"
+    assert entity.source_chunk == "John went to the market."
+    assert entity.context == "...John went to the..."
     assert entity.confidence == 0.95
 
 
@@ -30,11 +36,14 @@ def test_entity_optional_fields_defaults():
         type="object",
         source_file="story.md",
         chunk_id="c2",
+        source_chunk="A shiny sword lies here.",
+        context="...sword lies here...",
         confidence=0.8,
     )
 
     assert entity.id is None
     assert entity.description is None
+    assert entity.mentions == []
 
 
 def test_relationship_model_fields():
@@ -44,6 +53,7 @@ def test_relationship_model_fields():
         relation_type="friend",
         description="Childhood friends",
         confidence=0.9,
+        source_text="John and Mary have been friends since childhood.",
     )
 
     assert rel.source_entity == "John"
@@ -51,6 +61,7 @@ def test_relationship_model_fields():
     assert rel.relation_type == "friend"
     assert rel.description == "Childhood friends"
     assert rel.confidence == 0.9
+    assert rel.source_text == "John and Mary have been friends since childhood."
 
 
 def test_relationship_missing_required():

--- a/tests/test_utils/test_chunking.py
+++ b/tests/test_utils/test_chunking.py
@@ -32,3 +32,11 @@ def test_overlap_preservation():
         prev_tokens = enc.encode(chunks[i - 1]["text"])
         curr_tokens = enc.encode(chunks[i]["text"])
         assert prev_tokens[-5:] == curr_tokens[:5]
+
+
+def test_overlap_spacing():
+    text = "One two three four five six seven eight nine ten."
+    chunks = recursive_chunk_text(text, chunk_size=10, chunk_overlap=3)
+    for i in range(1, len(chunks)):
+        last_word = chunks[i - 1]["text"].split()[-1]
+        assert chunks[i]["text"].startswith(last_word + " ")


### PR DESCRIPTION
## Summary
- add mentions, source_chunk, and context fields to Entity model
- add source_text field to Relationship model
- fix spacing when adding overlap in chunks
- update unit tests for new fields and add spacing test

## Testing
- `pytest -q`
- Manual entity creation and chunk overlap check

------
https://chatgpt.com/codex/tasks/task_e_6851d586ab648321b59ea2a38a6972dc