### PR TITLE
Fix pip install in Docker and cleanup compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
 
 # Upgrade pip and install wheel
 RUN pip install --no-cache-dir --upgrade \
-    pip==23.3.1 \
+    pip==25.1.1 \
     setuptools==68.2.2 \
     wheel==0.41.2
 
@@ -27,7 +27,6 @@ RUN pip install --no-cache-dir \
     --timeout=300 \
     --retries=5 \
     --index-url=https://pypi.org/simple/ \
-    --extra-index-url=https://pypi.python.org/simple/ \
     -r requirements.txt
 
 # Copy application code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   postgres:


### PR DESCRIPTION
## Summary
- upgrade pip to 25.1.1 in Dockerfile and drop extra index URL
- remove obsolete `version` field from `docker-compose.yml`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68526b0266bc8321a11684e41839f7df